### PR TITLE
fixed no-parameter case in slurmfun

### DIFF
--- a/slurmfun.m
+++ b/slurmfun.m
@@ -87,7 +87,7 @@ parser.addRequired('func', @(x) isa(x, 'function_handle')||ischar(x));
 
 % partitions
 [~ ,defaultPartition] = get_available_partitions();
-parser.addParameter('partition', defaultPartition, ...
+parser.addParameter('partition', defaultPartition{1}, ...
     @validate_partition)
 
 % number of CPU Cores per job
@@ -126,7 +126,12 @@ parser.addParameter('waitForToolboxes', {}, @(x) all(ismember(x, availableToolbo
 
 % extract input arguments from varargin
 iFirstParameter = find(cellfun(@(x) ~iscell(x), varargin), 1);
-inputArguments = varargin(1:iFirstParameter-1);
+if isempty(iFirstParameter) % if no name-value pair parameters were given
+    inputArguments = varargin;
+else
+    inputArguments = varargin(1:iFirstParameter-1);
+end
+
 
 varargin = varargin(iFirstParameter:end);
 % input arguments


### PR DESCRIPTION
Currently, running slurmfun without optional name-value parameter pairs, such as for example `slurmfun(@sum,  {[1 2], [4 5]});`, returns:
```
Index exceeds the number of array elements (0).

Error in slurmfun (line 138)
nJobs = length(inputArguments{1});
```

This is due to line 128 currently assuming that at least one name-value parameter pair is given. I've added code that catches this edge case. In addition, the default setting for the 'partition'-parameter is currently a cell (`{'ESI'})`, but should be char (`'ESI'`). Line 90 has been modified accordingly.